### PR TITLE
fix root bg-color after "su" command

### DIFF
--- a/segments/username.py
+++ b/segments/username.py
@@ -1,6 +1,7 @@
 
 def add_username_segment():
     import os
+    import pwd
     if powerline.args.shell == 'bash':
         user_prompt = ' \\u '
     elif powerline.args.shell == 'zsh':
@@ -8,7 +9,7 @@ def add_username_segment():
     else:
         user_prompt = ' %s ' % os.getenv('USER')
 
-    if os.getenv('USER') == 'root':
+    if pwd.getpwuid(os.getuid())[ 0 ] == 'root':
         bgcolor = Color.USERNAME_ROOT_BG
     else:
         bgcolor = Color.USERNAME_BG


### PR DESCRIPTION
former method with $USER env variable does not work in case when root console acquired after "su" command
