### PR TITLE
Reset color if next element does not have colors

### DIFF
--- a/powerline-shell.py.template
+++ b/powerline-shell.py.template
@@ -74,10 +74,11 @@ class Powerline:
         next_segment = self.segments[idx + 1] if idx < len(self.segments)-1 else None
 
         return ''.join((
+            self.reset if segment[1] is None or segment[2] is None else '',
             self.fgcolor(segment[1]),
             self.bgcolor(segment[2]),
             segment[0],
-            self.bgcolor(next_segment[2]) if next_segment else self.reset,
+            self.bgcolor(next_segment[2]) if next_segment and next_segment[2] else self.reset,
             self.fgcolor(segment[4]),
             segment[3]))
 


### PR DESCRIPTION
This allows for an element to be empty or break the line

![no-color](https://cloud.githubusercontent.com/assets/121874/6168745/2dd81600-b2c8-11e4-8ae7-6292cfb359f8.png)

Example code:

```
def add_empty_segment():
    powerline.append("  empty  ", None, None, '', None)

add_empty_segment()
```

```
def add_newline_segment():
    powerline.append('\\n', None, None, '', None)

add_newline_segment()
```

I will open a PR for the newline segment, if you are interested.
