### PR TITLE
Do not evaluate GIT details over NFS

### DIFF
--- a/themes/basic.py
+++ b/themes/basic.py
@@ -21,6 +21,8 @@ class Color(DefaultColor):
     REPO_CLEAN_FG = 0  # black
     REPO_DIRTY_BG = 1  # red
     REPO_DIRTY_FG = 15 # white
+    REPO_UNKNOWN_BG = 33  # red
+    REPO_UNKNOWN_FG = 15 # white
 
     JOBS_FG = 14
     JOBS_BG = 8

--- a/themes/default.py
+++ b/themes/default.py
@@ -28,6 +28,8 @@ class DefaultColor:
     REPO_CLEAN_FG = 0  # black
     REPO_DIRTY_BG = 161  # pink/red
     REPO_DIRTY_FG = 15  # white
+    REPO_UNKNOWN_BG = 33 # blue
+    REPO_UNKNOWN_FG = 15  # white
 
     JOBS_FG = 39
     JOBS_BG = 238


### PR DESCRIPTION
I'm using NFS in some development boxes, and the prompt tends to evaluate 1-2 secs.

So this extensions checks the current filesystem and does not sum details on NFS.
