### PR TITLE
Only show directory for Version controlled directories

### DIFF
--- a/segments/cwd.py
+++ b/segments/cwd.py
@@ -1,5 +1,5 @@
 import os
-
+import subprocess
 
 def replace_home_dir(cwd):
     home = os.getenv('HOME')
@@ -18,6 +18,15 @@ def split_path_into_names(cwd):
         return ['/']
 
     return names
+
+def is_git_repo(cwd):
+    p = subprocess.Popen(['git', 'symbolic-ref', '-q', 'HEAD'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    out, err = p.communicate()
+
+    if 'Not a git repo' in err:
+        return False
+
+    return True
 
 
 def requires_special_home_display(name):
@@ -55,7 +64,7 @@ def add_cwd_segment():
     if powerline.args.cwd_mode == 'plain':
         powerline.append(' %s ' % (cwd,), Color.CWD_FG, Color.PATH_BG)
     else:
-        if (powerline.args.cwd_mode == 'dironly' or powerline.args.cwd_only):
+        if (powerline.args.cwd_mode == 'dironly' or powerline.args.cwd_only or is_git_repo(cwd)):
             # The user has indicated they only want the current directory to be
             # displayed, so chop everything else off
             names = names[-1:]


### PR DESCRIPTION
**Note**: Not good enough to merge

This change this:

![image](https://cloud.githubusercontent.com/assets/584253/10336931/db4c1ec4-6d19-11e5-8fa2-13cc6028a9f9.png)

to this:

![image](https://cloud.githubusercontent.com/assets/584253/10336943/f99a2dd0-6d19-11e5-82ff-d739da921e7a.png)

Its just enabling the dironly flag in case the user is in a git directory. Inspired by [gitster](https://github.com/shashankmehta/dotfiles/blob/master/thesetup/zsh/.oh-my-zsh/custom/themes/gitster.zsh-theme).

I'll shift this to a special flag and add support for other version controls, but only if this looks interesting to anyone else.

@b-ryan Thoughts?
