### PR TITLE
Segment for battery capacity

### DIFF
--- a/segments/battery.py
+++ b/segments/battery.py
@@ -12,7 +12,7 @@ def add_battery_segment():
     f.close()
     
     if status == 'Charging':
-        pwr = u' \u21ea '
+        pwr = u' \u26A1 '
     else:
         pwr = ' '
     

--- a/segments/battery.py
+++ b/segments/battery.py
@@ -1,0 +1,22 @@
+def add_battery_segment():
+    f = open('/sys/class/power_supply/BAT0/capacity')
+    cap = f.read().strip()
+    f.close()
+    
+    f = open('/sys/class/power_supply/BAT0/status')
+    status = f.read().strip()
+    f.close()
+    
+    if status == 'Charging':
+        pwr = u' \u21ea '
+    else:
+        pwr = ' '
+    
+    if int(cap) > 20:
+        bg = Color.HOME_BG
+    else:
+        bg = Color.READONLY_BG
+    
+    powerline.append(' ' + cap + '%' + pwr, Color.HOME_FG, bg)
+
+add_battery_segment()

--- a/segments/battery.py
+++ b/segments/battery.py
@@ -1,9 +1,13 @@
 def add_battery_segment():
-    f = open('/sys/class/power_supply/BAT0/capacity')
+    CAP_FILE = '/sys/class/power_supply/BAT0/capacity'
+    STATUS_FILE = '/sys/class/power_supply/BAT0/status'
+    LOW_BATTERY_THRESHOLD = 20
+    
+    f = open(CAP_FILE)
     cap = f.read().strip()
     f.close()
     
-    f = open('/sys/class/power_supply/BAT0/status')
+    f = open(STATUS_FILE)
     status = f.read().strip()
     f.close()
     
@@ -12,11 +16,13 @@ def add_battery_segment():
     else:
         pwr = ' '
     
-    if int(cap) > 20:
-        bg = Color.HOME_BG
+    if int(cap) < LOW_BATTERY_THRESHOLD:
+        bg = Color.BATTERY_LOW_BG
+        fg = Color.BATTERY_LOW_FG
     else:
-        bg = Color.READONLY_BG
+        bg = Color.BATTERY_NORMAL_BG
+        fg = Color.BATTERY_NORMAL_FG
     
-    powerline.append(' ' + cap + '%' + pwr, Color.HOME_FG, bg)
+    powerline.append(' ' + cap + '%' + pwr, fg, bg)
 
 add_battery_segment()

--- a/themes/default.py
+++ b/themes/default.py
@@ -42,6 +42,11 @@ class DefaultColor:
 
     VIRTUAL_ENV_BG = 35  # a mid-tone green
     VIRTUAL_ENV_FG = 00
+    
+    BATTERY_NORMAL_BG = 22
+    BATTERY_NORMAL_FG = 7
+    BATTERY_LOW_BG = 196
+    BATTERY_LOW_FG = 7
 
 class Color(DefaultColor):
     """


### PR DESCRIPTION
On linux (atleast Ubuntu) you can simply read battery capacity and status from the /sys/ filesystem. This patch does this and reports it as a segment.

This is my first venture into python, so feel free to give suggestions and critique..
