### PR TITLE
Add hg status info to hg segment similar to the git segment

### DIFF
--- a/segments/hg.py
+++ b/segments/hg.py
@@ -1,22 +1,42 @@
 import os
 import subprocess
 
+HG_SYMBOLS = {
+    'added': u'\u2713',
+    'modified': u'\u270E',
+    'removed': u'\u2715',
+    'missing': u'\u0021',
+    'untracked': u'?'
+}
+
+def _is_repo_dirty(stats):
+    dirty = False
+    for key, value in stats.iteritems():
+        if value > 0:
+            dirty = True
+    return dirty
+
+def _n_or_empty(_dict, _key):
+    return _dict[_key] if int(_dict[_key]) > 1 else u''
+
 def get_hg_status():
-    has_modified_files = False
-    has_untracked_files = False
-    has_missing_files = False
+    stats = {'added': 0, 'modified': 0, 'removed': 0, 'missing': 0, 'untracked': 0}
     output = subprocess.Popen(['hg', 'status'],
             stdout=subprocess.PIPE).communicate()[0]
     for line in output.split('\n'):
         if line == '':
             continue
-        elif line[0] == '?':
-            has_untracked_files = True
+        elif line[0] == 'A':
+            stats['added'] += 1
+        elif line[0] == 'M':
+            stats['modified'] += 1
+        elif line[0] == 'R':
+            stats['removed'] += 1
         elif line[0] == '!':
-            has_missing_files = True
-        else:
-            has_modified_files = True
-    return has_modified_files, has_untracked_files, has_missing_files
+            stats['missing'] += 1
+        elif line[0] == '?':
+            stats['untracked'] += 1
+    return stats
 
 def add_hg_segment():
     branch = os.popen('hg branch 2> /dev/null').read().rstrip()
@@ -24,16 +44,27 @@ def add_hg_segment():
         return False
     bg = Color.REPO_CLEAN_BG
     fg = Color.REPO_CLEAN_FG
-    has_modified_files, has_untracked_files, has_missing_files = get_hg_status()
-    if has_modified_files or has_untracked_files or has_missing_files:
+
+    stats = get_hg_status()
+
+    if _is_repo_dirty(stats):
         bg = Color.REPO_DIRTY_BG
         fg = Color.REPO_DIRTY_FG
-        extra = ''
-        if has_untracked_files:
-            extra += '+'
-        if has_missing_files:
-            extra += '!'
-        branch += (' ' + extra if extra != '' else '')
-    return powerline.append(' %s ' % branch, fg, bg)
+
+        powerline.append(' %s ' % branch, fg, bg)
+
+        def _add(_dict, _key, fg, bg):
+            if _dict[_key]:
+                _str = u' {}{} '.format(_n_or_empty(_dict, _key), HG_SYMBOLS[_key])
+                powerline.append(_str, fg, bg)
+
+        _add(stats, 'added', Color.HG_ADDED_FG, Color.HG_ADDED_BG)
+        _add(stats, 'modified', Color.HG_MODIFIED_FG, Color.HG_MODIFIED_BG)
+        _add(stats, 'removed', Color.HG_REMOVED_FG, Color.HG_REMOVED_BG)
+        _add(stats, 'missing', Color.HG_MISSING_FG, Color.HG_MISSING_BG)
+        _add(stats, 'untracked', Color.HG_UNTRACKED_FG, Color.HG_UNTRACKED_BG)
+    else:
+        powerline.append(' %s ' % branch, fg, bg)
+
 
 add_hg_segment()

--- a/themes/default.py
+++ b/themes/default.py
@@ -53,6 +53,17 @@ class DefaultColor:
     GIT_CONFLICTED_BG = 9
     GIT_CONFLICTED_FG = 15
 
+    HG_ADDED_BG = 34
+    HG_ADDED_FG = 15
+    HG_MODIFIED_BG = 20
+    HG_MODIFIED_FG = 15
+    HG_REMOVED_BG = 124
+    HG_REMOVED_FG = 15
+    HG_MISSING_BG = 9
+    HG_MISSING_FG = 15
+    HG_UNTRACKED_BG = 170
+    HG_UNTRACKED_FG = 15
+
     VIRTUAL_ENV_BG = 35  # a mid-tone green
     VIRTUAL_ENV_FG = 00
 


### PR DESCRIPTION
Similar to #136 I have added hg status information to the hg segment prompt.
- Number of added files -- ✓
- Number of modified files -- ✎
- Number of removed files -- &times;
- Number of missing files -- !
- Number of untracked files -- ?

These characters could just be updated to use the same values as HG: A, M, R, !, ?

The characters differ from the git segment version with the exception of the Modified files since they are slightly different statuses. Additionally, I have chosen colors that try to match the colors outputted by the hg status command. 

Unlike git, the incoming and outgoing change sets can be very costly for hg so they have been omitted from this update. 

This is the longest prompt possible:
![screen shot 2015-11-19 at 11 59 29 am](https://cloud.githubusercontent.com/assets/38108/11280185/aef62214-8ec2-11e5-9516-d808603cd306.png)

In the above example, each state has 2 changes, if there is only 1 change the number is omitted.
