### PR TITLE
Added correct escape sequence to term title segment 

### DIFF
--- a/segments/set_term_title.py
+++ b/segments/set_term_title.py
@@ -6,7 +6,7 @@ def add_set_term_title_segment(powerline):
     if powerline.args.shell == 'bash':
         set_title = '\\[\\e]0;\\u@\\h: \\w\\a\\]'
     elif powerline.args.shell == 'zsh':
-        set_title = '\033]0;%n@%m: %~\007'
+        set_title = '%{\033]0;%n@%m: %~\007%}'
     else:
         import socket
         set_title = '\033]0;%s@%s: %s\007' % (os.getenv('USER'), socket.gethostname().split('.')[0], powerline.cwd or os.getenv('PWD'))


### PR DESCRIPTION
Allows zsh to properly track width or command prompt. Escape sequences that change the color or other formatting aspects of the text, or that change the window title or other effects, have zero width. They need to be included within a percent-braces construct %{…%}
