### PR TITLE
aws_profile segment added

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 powerline-shell.py
 *.py[co]
 config.py
+
+.DS_Store
+*sublime*

--- a/README.md
+++ b/README.md
@@ -171,6 +171,12 @@ settings.
 
 # Changes
 
+2016-01-14
+
+* AWS profle support added per the `AWS_DEFAULT_PROFILE` setup described in [the AWS docs](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html)
+* `$ export AWS_DEFAULT_PROFILE=<NAME>`
+
+
 2015-12-26
 
 * Beginnings of unit testing for segments. Included in this change was a

--- a/segments/aws_profile.py
+++ b/segments/aws_profile.py
@@ -1,0 +1,11 @@
+
+def add_aws_profile_segment(powerline):
+    import os
+
+    aws_profile = os.environ.get('AWS_PROFILE') or \
+        os.environ.get('AWS_DEFAULT_PROFILE')
+
+    if aws_profile:
+        powerline.append(' aws:%s ' % os.path.basename(aws_profile),
+                         Color.AWS_PROFILE_FG,
+                         Color.AWS_PROFILE_BG)

--- a/themes/basic.py
+++ b/themes/basic.py
@@ -9,18 +9,18 @@ class Color(DefaultColor):
     HOSTNAME_BG = 7
 
     HOME_SPECIAL_DISPLAY = False
-    PATH_BG = 8 # dark grey
-    PATH_FG = 7 # light grey
-    CWD_FG = 15 # white
+    PATH_BG = 8  # dark grey
+    PATH_FG = 7  # light grey
+    CWD_FG = 15  # white
     SEPARATOR_FG = 7
 
     READONLY_BG = 1
     READONLY_FG = 15
 
-    REPO_CLEAN_BG = 2  # green
-    REPO_CLEAN_FG = 0  # black
-    REPO_DIRTY_BG = 1  # red
-    REPO_DIRTY_FG = 15 # white
+    REPO_CLEAN_BG = 2   # green
+    REPO_CLEAN_FG = 0   # black
+    REPO_DIRTY_BG = 1   # red
+    REPO_DIRTY_FG = 15  # white
 
     JOBS_FG = 14
     JOBS_BG = 8
@@ -35,3 +35,6 @@ class Color(DefaultColor):
 
     VIRTUAL_ENV_BG = 2
     VIRTUAL_ENV_FG = 0
+
+    AWS_PROFILE_FG = 14
+    AWS_PROFILE_BG = 8

--- a/themes/default.py
+++ b/themes/default.py
@@ -21,7 +21,7 @@ class DefaultColor:
     READONLY_BG = 124
     READONLY_FG = 254
 
-    SSH_BG = 166 # medium orange
+    SSH_BG = 166  # medium orange
     SSH_FG = 254
 
     REPO_CLEAN_BG = 148  # a light green color
@@ -55,6 +55,10 @@ class DefaultColor:
 
     VIRTUAL_ENV_BG = 35  # a mid-tone green
     VIRTUAL_ENV_FG = 00
+
+    AWS_PROFILE_FG = 39
+    AWS_PROFILE_BG = 238
+
 
 class Color(DefaultColor):
     """

--- a/themes/solarized-dark.py
+++ b/themes/solarized-dark.py
@@ -33,3 +33,6 @@ class Color(DefaultColor):
 
     VIRTUAL_ENV_BG = 15
     VIRTUAL_ENV_FG = 2
+
+    AWS_PROFILE_FG = 7
+    AWS_PROFILE_BG = 2

--- a/themes/washed.py
+++ b/themes/washed.py
@@ -33,3 +33,6 @@ class Color(DefaultColor):
 
     VIRTUAL_ENV_BG = 150
     VIRTUAL_ENV_FG = 0
+
+    AWS_PROFILE_FG = 0
+    AWS_PROFILE_BG = 7


### PR DESCRIPTION
Added `AWS_DEFAULT_PROFILE` segment for AWS CLI usage to support showing current profile.  Profile setup is defined in the [AWS docs](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html) .
