### PR TITLE
Bugfix. No prompt in python3 virtualenv.

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,8 @@ Add the following to your `.bashrc` (or `.profile` on Mac):
 
 ```
 function _update_ps1() {
-    PS1="$(/usr/bin/python ~/powerline-shell.py $? 2> /dev/null)"
+    POWERLINE_PYTHON="$(which python2.7 || which python2)"
+    PS1="$("$POWERLINE_PYTHON" ~/powerline-shell.py $? 2> /dev/null)"
 }
 
 if [ "$TERM" != "linux" ]; then

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Add the following to your `.bashrc` (or `.profile` on Mac):
 
 ```
 function _update_ps1() {
-    PS1="$(~/powerline-shell.py $? 2> /dev/null)"
+    PS1="$(/usr/bin/python ~/powerline-shell.py $? 2> /dev/null)"
 }
 
 if [ "$TERM" != "linux" ]; then
@@ -100,7 +100,7 @@ Add the following to your `.zshrc`:
 
 ```
 function powerline_precmd() {
-    PS1="$(~/powerline-shell.py $? --shell zsh 2> /dev/null)"
+    PS1="$(/usr/bin/python ~/powerline-shell.py $? --shell zsh 2> /dev/null)"
 }
 
 function install_powerline_precmd() {
@@ -122,7 +122,7 @@ Redefine `fish_prompt` in ~/.config/fish/config.fish:
 
 ```
 function fish_prompt
-    ~/powerline-shell.py $status --shell bare ^/dev/null
+    /usr/bin/python ~/powerline-shell.py $status --shell bare ^/dev/null
 end
 ```
 


### PR DESCRIPTION
powerline-shell called with the wrong python interpreter when used in 
virtualenv. Example:

`mkvirtualenv --python=/usr/bin/python3 powerline-shell _bugfix`
