### PR TITLE
Properly escape dollar signs in pathnames and other fields.

### DIFF
--- a/powerline_shell_base.py
+++ b/powerline_shell_base.py
@@ -71,7 +71,7 @@ class Powerline:
         return self.color('48', code)
 
     def append(self, content, fg, bg, separator=None, separator_fg=None):
-        self.segments.append((content, fg, bg,
+        self.segments.append((content.replace('$', '\$'), fg, bg,
             separator if separator is not None else self.separator,
             separator_fg if separator_fg is not None else bg))
 


### PR DESCRIPTION
I have some directories with dollar signs in their names. With powerline-shell, those dollar signs were not being escaped, so bash attempted to interpret them as variables, resulting in a garbled directory name being displayed.

This patch calls string.replace('$', '\$') to properly escape the dollar signs so they don't get interpreted as variables by bash.
