### PR TITLE
Fixes segments/set_term_title.py for ZSH

### DIFF
--- a/segments/set_term_title.py
+++ b/segments/set_term_title.py
@@ -6,7 +6,7 @@ def add_set_term_title_segment(powerline):
     if powerline.args.shell == 'bash':
         set_title = '\\[\\e]0;\\u@\\h: \\w\\a\\]'
     elif powerline.args.shell == 'zsh':
-        set_title = '\033]0;%n@%m: %~\007'
+        set_title = '%{\033]0;%n@%m: %~\007%}'
     else:
         import socket
         set_title = '\033]0;%s@%s: %s\007' % (os.getenv('USER'), socket.gethostname().split('.')[0], powerline.cwd or os.getenv('PWD'))


### PR DESCRIPTION
The %{ and %} quoting was missing that instructs ZSH to consider this
part to have zero width. This broke history searching and long command
lines. See e.g. http://stackoverflow.com/a/11916552/159834
