### PR TITLE
added another env variable for CONDA environment

### DIFF
--- a/segments/virtual_env.py
+++ b/segments/virtual_env.py
@@ -1,7 +1,7 @@
 import os
 
 def add_virtual_env_segment(powerline):
-    env = os.getenv('VIRTUAL_ENV') or os.getenv('CONDA_ENV_PATH')
+    env = os.getenv('VIRTUAL_ENV') or os.getenv('CONDA_ENV_PATH') or os.getenv('CONDA_PREFIX')
     if env is None:
         return
 


### PR DESCRIPTION
Tested with my Mac with conda 4.3.14 it seems it adds CONDA_PREFIX environment variabile which is reporting the environment's path.