### PR TITLE
Fix cmd execution via unescaped git branch names

### DIFF
--- a/segments/git.py
+++ b/segments/git.py
@@ -1,6 +1,7 @@
 import re
 import subprocess
 import os
+import shlex
 
 def get_PATH():
     """Normally gets the PATH from the OS. This function exists to enable
@@ -23,7 +24,7 @@ def git_subprocess_env():
 
 
 def parse_git_branch_info(status):
-    info = re.search('^## (?P<local>\S+?)''(\.{3}(?P<remote>\S+?)( \[(ahead (?P<ahead>\d+)(, )?)?(behind (?P<behind>\d+))?\])?)?$', status[0])
+    info = re.search('^## (?P<local>\S+?)''(\.{3}(?P<remote>\S+?)( \[(ahead (?P<ahead>\d+)(, )?)?(behind (?P<behind>\d+))?\])?)?$', shlex.quote(status[0]))
     return info.groupdict() if info else None
 
 


### PR DESCRIPTION
When parsing the git branch name it is possible to execute arbitrary
code via unescaped characters in that branch's name.

See POC here: https://github.com/njhartwell/pw3nage