### PR TITLE
Escape subshell commands

### DIFF
--- a/powerline_shell/__init__.py
+++ b/powerline_shell/__init__.py
@@ -100,8 +100,7 @@ class Powerline(object):
         return self.color('48', code)
 
     def append(self, content, fg, bg, separator=None, separator_fg=None):
-        sanitized = re.sub(r"([`$])", r"\\\1", content)
-        self.segments.append((sanitized, fg, bg,
+        self.segments.append((content, fg, bg,
             separator if separator is not None else self.separator,
             separator_fg if separator_fg is not None else bg))
 
@@ -115,12 +114,16 @@ class Powerline(object):
 
     def draw_segment(self, idx):
         segment = self.segments[idx]
+        if self.args.shell == "bash":
+            sanitized = re.sub(r"([`$])", r"\\\1", segment[0])
+        else:
+            sanitized = segment[0]
         next_segment = self.segments[idx + 1] if idx < len(self.segments)-1 else None
 
         return ''.join((
             self.fgcolor(segment[1]),
             self.bgcolor(segment[2]),
-            segment[0],
+            sanitized,
             self.bgcolor(next_segment[2]) if next_segment else self.reset,
             self.fgcolor(segment[4]),
             segment[3]))

--- a/powerline_shell/__init__.py
+++ b/powerline_shell/__init__.py
@@ -7,6 +7,7 @@ import sys
 import importlib
 import json
 from .utils import warn, py3
+import re
 
 
 def get_valid_cwd():
@@ -100,7 +101,8 @@ class Powerline(object):
         return self.color('48', code)
 
     def append(self, content, fg, bg, separator=None, separator_fg=None):
-        self.segments.append((content, fg, bg,
+        sanitized = re.sub(r"([`$])", r"\\\1", content)
+        self.segments.append((sanitized, fg, bg,
             separator if separator is not None else self.separator,
             separator_fg if separator_fg is not None else bg))
 


### PR DESCRIPTION
Maybe a viable fix for https://github.com/banga/powerline-shell/pull/264 ?

I couldn't find any workable solution using existing python code. Even `shlex.quote` didn't seem to work from my testing. Instead, this branch escapes backticks and the dollar sign. 

Tests:


![selection_005](https://user-images.githubusercontent.com/1183997/30255463-137caa6a-9672-11e7-90b5-dc110a0cbb7d.png)

Some thoughts:

- This is only appropriate for bash & maybe zsh. I'm also not sure it's a sufficient change.