### PR TITLE
Redo fossil segment to use RepoStats

### DIFF
--- a/powerline_shell/segments/fossil.py
+++ b/powerline_shell/segments/fossil.py
@@ -50,7 +50,7 @@ def build_stats():
         return (None, None)
     changes = os.popen("fossil changes 2>/dev/null").read().strip().split("\n")
     extra = os.popen("fossil extras 2>/dev/null").read().strip().split("\n")
-    extra = ["EXTRA " + filename for filename in extra]
+    extra = ["EXTRA " + filename for filename in extra if filename != ""]
     if changes == extra == ['']:
         return (RepoStats(), branch)
     status = [line for line in changes + extra if line != '']

--- a/powerline_shell/segments/fossil.py
+++ b/powerline_shell/segments/fossil.py
@@ -1,53 +1,73 @@
 import os
 import subprocess
-from ..utils import ThreadedSegment
+from ..utils import RepoStats, ThreadedSegment
 
 
-def get_fossil_branch():
-    try:
-        subprocess.Popen(['fossil'], stdout=subprocess.PIPE).communicate()
-    except OSError:
-        return None
+def get_PATH():
+    """Normally gets the PATH from the OS. This function exists to enable
+    easily mocking the PATH in tests.
+    """
+    return os.getenv("PATH")
+
+
+def fossil_subprocess_env():
+    return {"PATH": get_PATH()}
+
+
+def _get_fossil_branch():
+    branches = os.popen("fossil branch 2>/dev/null").read().strip().split("\n")
     return ''.join([
         i.replace('*','').strip()
-        for i in os.popen("fossil branch 2> /dev/null").read().strip().split("\n")
+        for i in branches
         if i.startswith('*')
     ])
 
 
-def get_fossil_status():
-    has_modified_files = False
-    has_untracked_files = False
-    has_missing_files = False
-    output = os.popen('fossil changes 2>/dev/null').read().strip()
-    has_untracked_files = bool(
-        os.popen("fossil extras 2>/dev/null").read().strip()
-    )
-    has_missing_files = 'MISSING' in output
-    has_modified_files = 'EDITED' in output
-    return has_modified_files, has_untracked_files, has_missing_files
+def parse_fossil_stats(status):
+    stats = RepoStats()
+    for filestatus in [line.split()[0] for line in status.strip().split("\n")]:
+        if filestatus == "ADDED":
+            stats.staged += 1
+        elif filestatus == "EXTRA":
+            stats.new += 1
+        elif filestatus == "CONFLICT":
+            stats.conflicted += 1
+        else:
+            stats.changed += 1
+    return stats
+
+
+def build_stats():
+    try:
+        subprocess.Popen(['fossil'], stdout=subprocess.PIPE,
+                         stderr=subprocess.PIPE,
+                         env=fossil_subprocess_env()).communicate()
+    except OSError:
+        # Popen will throw an OSError if fossil is not found
+        return (None, None)
+    branch = _get_fossil_branch()
+    if branch == "":
+        return (None, None)
+    status = os.popen("fossil changes --differ 2>/dev/null").read().strip()
+    if status == "":
+        return (RepoStats(), branch)
+    stats = parse_fossil_stats(status)
+    return stats, branch
 
 
 class Segment(ThreadedSegment):
     def run(self):
-        self.branch = get_fossil_branch()
-        self.status = get_fossil_status() if self.branch else None
+        self.stats, self.branch = build_stats()
 
     def add_to_powerline(self):
         self.join()
-        powerline = self.powerline
-        if not self.branch or not self.status:
+        if not self.stats:
             return
-        has_modified, has_untracked, has_missing = self.status
-        bg = powerline.theme.REPO_CLEAN_BG
-        fg = powerline.theme.REPO_CLEAN_FG
-        if has_modified or has_untracked or has_missing:
-            bg = powerline.theme.REPO_DIRTY_BG
-            fg = powerline.theme.REPO_DIRTY_FG
-            extra = ''
-            if has_untracked:
-                extra += '+'
-            if has_missing:
-                extra += '!'
-            self.branch += (' ' + extra if extra != '' else '')
-        powerline.append(' %s ' % self.branch, fg, bg)
+        bg = self.powerline.theme.REPO_CLEAN_BG
+        fg = self.powerline.theme.REPO_CLEAN_FG
+        if self.stats.dirty:
+            bg = self.powerline.theme.REPO_DIRTY_BG
+            fg = self.powerline.theme.REPO_DIRTY_FG
+
+        self.powerline.append(" " + self.branch + " ", fg, bg)
+        self.stats.add_to_powerline(self.powerline)

--- a/powerline_shell/segments/fossil.py
+++ b/powerline_shell/segments/fossil.py
@@ -25,7 +25,7 @@ def _get_fossil_branch():
 
 def parse_fossil_stats(status):
     stats = RepoStats()
-    for filestatus in [line.split()[0] for line in status.strip().split("\n")]:
+    for filestatus in [line.split()[0] for line in status]:
         if filestatus == "ADDED":
             stats.staged += 1
         elif filestatus == "EXTRA":
@@ -48,8 +48,10 @@ def build_stats():
     branch = _get_fossil_branch()
     if branch == "":
         return (None, None)
-    status = os.popen("fossil changes --differ 2>/dev/null").read().strip()
-    if status == "":
+    status = os.popen("fossil changes 2>/dev/null").read().strip().split("\n")
+    extra = os.popen("fossil extras 2>/dev/null").read().strip().split("\n")
+    status += ["EXTRA " + filename for filename in extra if filename != ""]
+    if status == ['']:
         return (RepoStats(), branch)
     stats = parse_fossil_stats(status)
     return stats, branch

--- a/powerline_shell/segments/fossil.py
+++ b/powerline_shell/segments/fossil.py
@@ -25,12 +25,12 @@ def _get_fossil_branch():
 
 def parse_fossil_stats(status):
     stats = RepoStats()
-    for filestatus in [line.split()[0] for line in status]:
-        if filestatus == "ADDED":
+    for line in status:
+        if line.startswith("ADDED"):
             stats.staged += 1
-        elif filestatus == "EXTRA":
+        elif line.startswith("EXTRA"):
             stats.new += 1
-        elif filestatus == "CONFLICT":
+        elif line.startswith("CONFLICT"):
             stats.conflicted += 1
         else:
             stats.changed += 1
@@ -48,11 +48,12 @@ def build_stats():
     branch = _get_fossil_branch()
     if branch == "":
         return (None, None)
-    status = os.popen("fossil changes 2>/dev/null").read().strip().split("\n")
+    changes = os.popen("fossil changes 2>/dev/null").read().strip().split("\n")
     extra = os.popen("fossil extras 2>/dev/null").read().strip().split("\n")
-    status += ["EXTRA " + filename for filename in extra if filename != ""]
-    if status == ['']:
+    extra = ["EXTRA " + filename for filename in extra]
+    if changes == extra == ['']:
         return (RepoStats(), branch)
+    status = [line for line in changes + extra if line != '']
     stats = parse_fossil_stats(status)
     return stats, branch
 

--- a/test/repo_stats_test.py
+++ b/test/repo_stats_test.py
@@ -19,7 +19,7 @@ class RepoStatsTest(unittest.TestCase):
         self.assertEqual(self.repo_stats.n_or_empty("changed"), u"")
 
     def test_n_or_empty__n(self):
-        self.assertEqual(self.repo_stats.n_or_empty("conflicted"), u"4")
+        self.assertEqual(self.repo_stats.n_or_empty("conflicted"), 4)
 
     def test_index(self):
         self.assertEqual(self.repo_stats["changed"], 1)

--- a/test/segments_test/fossil_test.py
+++ b/test/segments_test/fossil_test.py
@@ -1,0 +1,68 @@
+import unittest
+import mock
+import tempfile
+import shutil
+import sh
+import powerline_shell.segments.fossil as fossil
+from powerline_shell.utils import RepoStats
+
+
+rs = RepoStats()
+test_cases = {
+    "EXTRA      new-file": rs.symbols["new"],
+    "EDITED     modified-file": rs.symbols["changed"],
+    "CONFLICT   conflicted-file": rs.symbols["conflicted"],
+    "ADDED      added-file": rs.symbols["staged"],
+}
+
+
+class FossilTest(unittest.TestCase):
+
+    def setUp(self):
+        self.powerline = mock.MagicMock()
+
+        self.dirname = tempfile.mkdtemp()
+        sh.cd(self.dirname)
+        sh.fossil("init", "test.fossil")
+        sh.fossil("open", "test.fossil")
+
+        self.segment = fossil.Segment(self.powerline)
+
+    def tearDown(self):
+        shutil.rmtree(self.dirname)
+
+    def _add_and_commit(self, filename):
+        sh.touch(filename)
+        sh.fossil("add", filename)
+        sh.fossil("commit", "-m", "add file " + filename)
+
+    def _checkout_new_branch(self, branch):
+        sh.fossil("branch", "new", branch, "trunk")
+
+    @mock.patch("powerline_shell.segments.fossil.get_PATH")
+    def test_fossil_not_installed(self, get_PATH):
+        get_PATH.return_value = "" # so fossil can't be found
+        self.segment.start()
+        self.segment.add_to_powerline()
+        self.assertEqual(self.powerline.append.call_count, 0)
+
+    def test_non_fossil_directory(self):
+        sh.fossil("close", "--force")
+        self.segment.start()
+        self.segment.add_to_powerline()
+        self.assertEqual(self.powerline.append.call_count, 0)
+
+    def test_standard(self):
+        self._add_and_commit("foo")
+        self.segment.start()
+        self.segment.add_to_powerline()
+        self.assertEqual(self.powerline.append.call_args[0][0], " trunk ")
+
+    @mock.patch('powerline_shell.segments.fossil._get_fossil_status')
+    def test_all(self, check_output):
+        for stdout, result in test_cases.items():
+            check_output.return_value = [stdout]
+            self.segment.start()
+            self.segment.add_to_powerline()
+            self.assertEqual(self.powerline.append.call_args[0][0].split()[0],
+                             result)


### PR DESCRIPTION
Includes a hack to make it work in older versions of fossil that throw an error with `fossil changes --differ`, like version 1.37 does.