### PR TITLE
Dockerize tests for easy reproducibility.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+*.swp
+.git/
+.gitignore
+.travis.yml
+CHANGELOG.md
+Dockerfile
+LICENSE
+README.md
+bash-powerline-screenshot.png

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
-language: python
-script: |
-  ./setup.py install
-  pip install -r requirements-dev.txt
-  nosetests
+sudo: required
+services:
+  - docker
+script: ./test.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER github.com/banga/powerline-shell
 ENV USER docker
 ENV USERNAME "Docker User"
 
-# Create a 'docker' user because we might not want to run everything as 'root'. Use 9999 as the ID
+# Create a 'docker' user because we do not want to run everything as 'root'. Use 9999 as the ID
 # to keep it specific and away from the IDs in the host system.
 RUN addgroup -g 9999 $USER && \
     adduser -u 9999 -G $USER -g "$USERNAME" -s /bin/bash -D $USER
@@ -33,7 +33,8 @@ RUN bzr whoami "$USERNAME <$USER@example.com>" && \
 
 COPY . ./
 USER root
-RUN chown -R docker:docker .
+RUN ./setup.py install && \
+    chown -R docker:docker .
 
 USER docker
-RUN nosetests
+ENTRYPOINT ["/bin/sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,39 @@
+FROM python:2.7-alpine
+
+MAINTAINER github.com/banga/powerline-shell
+
+ENV USER docker
+ENV USERNAME "Docker User"
+
+# Create a 'docker' user because we might not want to run everything as 'root'. Use 9999 as the ID
+# to keep it specific and away from the IDs in the host system.
+RUN addgroup -g 9999 $USER && \
+    adduser -u 9999 -G $USER -g "$USERNAME" -s /bin/bash -D $USER
+
+RUN apk add --no-cache --update \
+      bzr \
+      fossil \
+      git \
+      mercurial \
+      php5 \
+      subversion && \
+    rm -rf /var/cache/apk/*
+
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+# Cache the dev requirements.
+COPY requirements-dev.txt .
+RUN pip install -r requirements-dev.txt
+
+USER docker
+RUN bzr whoami "$USERNAME <$USER@example.com>" && \
+    git config --global user.email "$USER@example.com" && \
+    git config --global user.name "$USERNAME"
+
+COPY . ./
+USER root
+RUN chown -R docker:docker .
+
+USER docker
+RUN nosetests

--- a/README.md
+++ b/README.md
@@ -256,8 +256,10 @@ Make sure you introduce new default colors in `themes/default.py` for every new
 segment you create. Test your segment with this theme first.
 
 You should add tests for your segment as best you are able. Unit and
-integration tests are both welcome. Run your tests with the `nosetests` command
-after install the requirements in `requirements-dev.txt`.
+integration tests are both welcome. Run your tests by running the `test.sh`
+script. It uses `docker` to manage dependencies and the environment.
+Alternatively, you can run the `nosetests` command after installing the
+requirements in `requirements-dev.txt`.
 
 ## Troubleshooting
 

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+docker build -t powerline-shell .
+docker run --rm -it powerline-shell -c nosetests


### PR DESCRIPTION
The current way of testing requires the user's computer to have all the prerequisites installed locally. I found this out because the only version control I had installed was `git`. I didn't want to install them all, so I created a `Dockerfile` to run the tests in a container. I found it very useful and hence wanted to contribute those back to the main repository. This commit:

* Dockerizes the tests.
* Creates a script to run tests.
* Enables `docker` in Travis.